### PR TITLE
Fix update endpoint parameter order

### DIFF
--- a/routers/items.py
+++ b/routers/items.py
@@ -114,8 +114,8 @@ async def create_item(item: ItemCreate):
 
 @router.put("/{item_id}", response_model=Item, summary="Update item")
 async def update_item(
+    item_update: ItemUpdate,
     item_id: int = Path(..., gt=0, description="The ID of the item to update"),
-    item_update: ItemUpdate = None
 ):
     item = next((item for item in fake_items_db if item["id"] == item_id), None)
     if not item:

--- a/routers/users.py
+++ b/routers/users.py
@@ -82,8 +82,8 @@ async def create_user(user: UserCreate):
 
 @router.put("/{user_id}", response_model=User, summary="Update user")
 async def update_user(
+    user_update: UserUpdate,
     user_id: int = Path(..., gt=0, description="The ID of the user to update"),
-    user_update: UserUpdate = None
 ):
     user = next((user for user in fake_users_db if user["id"] == user_id), None)
     if not user:


### PR DESCRIPTION
## Summary
- make body data required for user and item update endpoints

## Testing
- `python -m py_compile main.py routers/items.py routers/users.py models/schemas.py utils/exceptions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654ace89e48323b624ac2789ef16ae